### PR TITLE
feat: adds blog. updates blog path to be /blog

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { defineConfig } from 'astro/config';
+import { defineConfig, fontProviders } from 'astro/config';
 
 import tailwindcss from '@tailwindcss/vite';
 
@@ -16,6 +16,6 @@ export default defineConfig({
   integrations: [mdx()],
   redirects: {
     "/blog/my-blog/dpi-map-data-for-statistical-analysis": "/blog/dpi-map-data-for-statistical-analysis",
-    "blog/my-blog/dpi-dataset-update-mar-2025": "blog/dpi-dataset-update-mar-2025"
+    "/blog/my-blog/dpi-dataset-update-mar-2025": "/blog/dpi-dataset-update-mar-2025"
   }
 })

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,6 +15,7 @@ export default defineConfig({
   },
   integrations: [mdx()],
   redirects: {
-    "/blog/my-blog/[...slug]": "/blog/[...slug]"
+    "/blog/my-blog/dpi-map-data-for-statistical-analysis": "/blog/dpi-map-data-for-statistical-analysis",
+    "blog/my-blog/dpi-dataset-update-mar-2025": "blog/dpi-dataset-update-mar-2025"
   }
 })

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { defineConfig, fontProviders } from 'astro/config';
+import { defineConfig } from 'astro/config';
 
 import tailwindcss from '@tailwindcss/vite';
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,5 +13,8 @@ export default defineConfig({
   vite: {
     plugins: [tailwindcss()]
   },
-  integrations: [mdx()]
-});
+  integrations: [mdx()],
+  redirects: {
+    "/blog/my-blog/[...slug]": "/blog/[...slug]"
+  }
+})

--- a/src/components/Blog.astro
+++ b/src/components/Blog.astro
@@ -1,0 +1,19 @@
+---
+import { getCollection } from 'astro:content'
+const posts = await getCollection('blog', ({data}) => data.published)
+posts.sort(
+  (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
+)
+
+---
+
+<ul>
+  { posts.map(p => (
+    <li>
+      <span class="font-bold">{p.data.date.toLocaleDateString('en', {month: "short", year: 'numeric'})}</span> - 
+      <a href={`/blog/${p.id}`}>
+        {p.data.title}
+      </a>
+    </li>
+  ))}
+</ul>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,13 @@
+import { defineCollection, z } from 'astro:content'
+import { glob } from 'astro/loaders'
+
+const blog = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/pages/blog" }),
+  schema: z.object({
+    title: z.string(),
+    date: z.date(),
+    published: z.boolean().optional().default(true)
+  })
+})
+
+export const collections = { blog }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -30,7 +30,7 @@ const imgUrl = new URL('/map/preview.png', rootUrl)
 		<meta property="twitter:description" content={desc} />
 		<meta property="twitter:image" content={imgUrl} />
 	</head>
-	<body>
+	<body class={Astro.props.bodyClass ?? ''}>
 		<Header />
 		<slot />
 	</body>

--- a/src/layouts/Standard.astro
+++ b/src/layouts/Standard.astro
@@ -3,7 +3,7 @@ import Layout from "./Layout.astro"
 const title = Astro.props.frontmatter?.title ?? Astro.props.title
 ---
 
-<Layout title={title}>
+<Layout title={title} bodyClass={Astro.props.bodyClass}>
 	<article class="prose py-10 max-w-2xl mx-auto px-2 md:px-0">
 		<slot/>
 	</article>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,15 @@
+---
+import Layout from '../layouts/Standard.astro'
+---
+
+<Layout bodyClass="bg-zinc-200">
+  <div class="flex flex-col items-center justify-center h-[600px]">
+    <div class="card bg-white text-center">
+      <div class="p-8">
+        <h1>404</h1>
+      <p class="pb-4">That page was not found</p>
+      <div class="text-center py-4"><a href="/" class="button-blue">Back to the map</a></div>
+      </div>
+    </div>
+  </div>
+</Layout>

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -2,6 +2,8 @@
 layout: ../layouts/Standard.astro
 title: 'About'
 ---
+import Blog from '../components/Blog.astro'
+
 
 # About
 
@@ -11,11 +13,7 @@ The **DPI Mapping project** aims to advance our understanding of digital public 
 - Communicating the "[State of DPI](/global-state-of-dpi/)" and promoting collaboration across the ecosystem.
 - Highlighting opportunities to support DPI deployment and develop safeguards.
 
-<div class="text-center py-4">
-  <a href="https://forms.gle/dhoXGR9M6fVAoDKt7" class="button-blue">
-    Sign up to the newsletter
-  </a>
-</div>
+<div class="text-center py-4"><a href="https://forms.gle/dhoXGR9M6fVAoDKt7" class="button-blue">Sign up to the newsletter</a></div>
 
 Over fifty national governments have committed to build national-scale digital public infrastructure in the coming years. Despite this pledge, it remains challenging to measure the number and status of DPI pilots and deployments globally. 
 
@@ -25,7 +23,13 @@ The DPI Map addresses this. It offers the first global investigation of digital 
 
 ---
 
-# Timeline
+## Updates
+
+<Blog />
+
+---
+
+## Timeline
 
 - **Oct 2025** - Global State of DPI Report
 - **Mar 2025** - Launch of the DPI Measurement Community of Practice Global Dataset Update (Q1 2025)
@@ -39,7 +43,7 @@ The DPI Map addresses this. It offers the first global investigation of digital 
 
 ---
 
-# Team
+## Team
 
 <div class="grid gap-3 grid-cols-2 md:grid-cols-3 lg:grid-cols-6 lg:-mx-30 content-start">
 
@@ -132,7 +136,7 @@ IIPP UCL
 </div>
 
 
-# Alumni
+## Alumni
 
 <div class="grid gap-3 grid-cols-2 md:grid-cols-3 lg:grid-cols-6 lg:-mx-30 content-start">
 
@@ -180,7 +184,7 @@ IIPP UCL
 </div>
 
 
-# Contributors
+## Contributors
 
 This project is led by the [Institute for Innovation and Public Purpose (IIPP)](https://www.ucl.ac.uk/bartlett/public-purpose/ucl-institute-innovation-and-public-purpose) at University College London UCL. It is presently supported by [Co-Develop](https://www.codevelop.fund/).
 

--- a/src/pages/blog/dpi-dataset-update-mar-2025.md
+++ b/src/pages/blog/dpi-dataset-update-mar-2025.md
@@ -1,0 +1,48 @@
+---
+layout: ../../layouts/Standard.astro
+title: 'DPI Dataset Update'
+date: 2025-03-31
+---
+
+# DPI Dataset Update
+
+The DPI Map Team is delighted to share that a new dataset update is [now live](https://dpimap.org/dpimap) on our website. Since our initial launch in October 2024, our team captured a first glance of government efforts to deploy federal level DPI systems: digital identity, digital payment, and data exchange systems across 210 countries. Our latest update offers new insights into the evolving landscape of digital public infrastructure worldwide and what you can find with our latest changes.
+
+## What’s changed on the map?
+
+Our latest updated dataset includes several formatting changes providing a more comprehensive outline of DPI developments.
+
+- **Updated Deployment Statuses**: The current implementation statuses have been regrouped into two fixed statuses to provide a clearer view of each country's DPI deployments and their statuses:
+  - **Planned/Piloted** - Systems in planning or pilot testing phases.
+  - **Implemented Digital tools have been deployed to the public.**
+- **System vs Sub-system Variables**: We've added differentiation between country-level and system-level technical details, allowing for a more nuanced understanding of each deployment.
+- **Time Stamped Data**: We’ve included a new column to see countries that have been updated with new information. You can expect new dataset updates every quarter.
+
+<aside>
+
+Have questions about specific variables? Visit our [codebook](https://docs.google.com/spreadsheets/d/1JbpmZ1ap235wVCTcnA1dE5ghCWEzdFJXxyZz1FTRupk/edit?usp=sharing).
+
+</aside>
+
+## DPI Highlights: Country-level updates
+
+The following includes some of the added information to the latest dataset.
+
+- 🇹🇿 **Tanzania’s _Jamii X-Change_** is designed to facilitate interoperability between platforms, encompassing three key modules: Jamii Namba, Jamii Kadi, Jamii Malipo, enabling secure data sharing between public and private organizations.
+- 🇦🇿 **Azerbaijan**’s _Digital Login_ system streamlines access to over 150 government portals through a single sign-on mechanism, enhancing user convenience and security. The system offers multiple authentication methods, including facial recognition, simplifying the identification process and improving citizen satisfaction.
+- 🇱🇰 **Sri Lanka**’s _Lanka Pay_ offers a selection of services including the Common ATM Switch (CAS) which unifies ATMS across banks, the common Electronic Fund Transfer Switches (CEFTS) enabling real-time interbank fund transfers.
+- 🇮🇹 **Italy**’s _SPID (Sistema Pubblico di Identità Digitale)_ allows citizens to access public administration online services with a single set of credentials. Additionally, the _CIE (Carta d'Identità Elettronica)_ also serves as an electronic identity card, providing official identification, facilitating access to online services.
+- 🇨🇭 **Switzerland**’s latest central payment infrastructure, _Swiss Interbank Clearing 5 (SIC5),_ real-time gross settlement (RTGS), enables instant payments, allowing individuals and businesses to complete transactions instantly.
+
+<aside>
+
+All these updates have been recorded in the new dataset (accessible under ‘Version Management’ on the front page. Read about them [here](/data).
+
+</aside>
+
+
+## Stay connected
+
+We would like to thank our contributors' from: **Ministry of Trade, Co-operatives and Small and Medium Enterprises (Fiji), Ministry of Communications and Information Technology (Egypt), Innovation and Digital Development Agency (Azerbaijan)** and **Department for Digital Transformation (Italy)**, for their engagement on the DPI map.
+
+The contributions have been  essential to keeping our map updated with the latest digital developments. **[We welcome our full community’s engagement](https://dpimap.org/contribute-to-the-dpi-map)**on new DPI deployments, feedback, or knowledge sharing.

--- a/src/pages/blog/dpi-map-data-for-statistical-analysis.md
+++ b/src/pages/blog/dpi-map-data-for-statistical-analysis.md
@@ -1,0 +1,36 @@
+---
+layout: ../../layouts/Standard.astro
+title: 'DPI Map Data for Statistical Analysis'
+date: 2025-04-30
+---
+
+# DPI Map Data for Statistical Analysis
+
+The **DPI Map dataset for statistical analysis** is a cross-national and cross-sectional policy database of technology characteristics, policies and adoption metrics related to digital public infrastructure across a maximum of 218 geographical entities (countries, regions/continents). The dataset comprises three distinct sets: one for digital identity systems, digital payment systems, and one for data exchange systems.
+
+<aside>
+
+Access the dataset [here](https://drive.google.com/drive/folders/1Xuzfwj8YZVWnvSIRESKuhsvqIlYfXWgM?usp=sharing).
+
+</aside>
+
+The previous dataset has been updated to ease usage for analysis with statistical software, with its new version now reflecting information from October 2024. The interactive [DPI Map dataset](https://dpimap.org/data) will continue to be updated every quarter as information is reported, whereas the Data Repository will be updated and released with version control regularly, planned to be released annually.
+
+The digital identity dataset collects information on policies from 210 countries across 29 variables. The digital payment system dataset spans 218 geographical entities, of which 210 are countries. 7 entries are related to wider continental or institutional policies, across 47 variables. Lastly, the data exchange system dataset spans 210 geographical entities, one of which relates to institutional policies, with the rest being rooted in country-specific policies. Information is recorded across 27 variables. Variables included in each dataset provide information and contextual data on participation mechanisms, institutional involvement in the respective policy, legal and procedural matters and technical details.
+
+Firstly, the structure of the dataset was adjusted. Whereas the interactive DPI Map dataset records information with countries as a unit of analysis, the Statistical dataset codes information on the basis of policies. Countries with multiple DPI policies are now represented multiple times in the dataset.
+
+New variables have been added to enable policy-specific analysis, and some existing variables have been revised.
+
+- A new ordinal variable on the **status of implementation** has been added to all three datasets with a streamlined scale to allow for cross-analysis.
+- For variables that can take **multiple values for a single unit**, a new binary variable was coded. For instance, in the variable for types of entities that can participate in data exchange systems, values can take either public, private, civil, or multiple of the aforementioned.
+- Three binary variables have been added to record the **adoption of DPI by different types of participants**. This approach has also been applied to the variables for types of transactions supported and the type of settlement system in the digital payment dataset.
+- Further, ordinal variables have been coded for **variables that previously held financial values**. These were often coded in ranges. These ranges have now been streamlined into 5 distinct levels. This applies to the variables for annual transaction values, annual volume of transactions and cost of transactions, all in the digital payment dataset.
+- Lastly, values previously coded as “Unknown” are now simply labelled as **Not Available (NA)**.
+- **Ordinal and categorical variables** have been cleaned, and duplicate variables with slightly differing spellings of values have been streamlined.
+
+<aside>
+
+Our [codebook](https://docs.google.com/spreadsheets/d/1JbpmZ1ap235wVCTcnA1dE5ghCWEzdFJXxyZz1FTRupk/edit?usp=drive_link) can help simplify studying both datasets. Or write to us at [dpimappingucl@gmail.com](mailto:dpimappingucl@gmail.com) with questions.
+
+</aside>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,9 @@
+---
+import Layout from '../../layouts/Standard.astro'
+import Blog from "../../components/Blog.astro";
+---
+
+<Layout>
+  <h1>Blog</h1>
+  <Blog/>
+</Layout>


### PR DESCRIPTION
The about page now has an "Updates" section which shows the list of blog posts.

also adds a /blog route to show the list of blog posts, and a page per blog post.

License: MIT