### PR TITLE
fix: pick the most dpi-like where a country has more than one

### DIFF
--- a/src/DataExchange.ts
+++ b/src/DataExchange.ts
@@ -4,7 +4,7 @@ import { fixURL } from './Util'
 
 type DataExchangeType = typeof dataJSON[number]
 
-export function dataExchangeDPIStatus(x: DataExchangeType) {
+export function dataExchangeDPIStatus(x: DataExchangeType): "DPI" | "WIP" | "NA" {
   const implStatus = normaliseImplementationStatus(x['Status of implementation'])
   if (x['Count for DPI-like data exchange system'] === 1) {
     return 'DPI'

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -8,7 +8,7 @@ type IdentityType = typeof json[number]
  * Derive DPI status for project.
  * @returns "DPI" | "WIP" | "NA"
  */
-export function identityDPIStatus(x: IdentityType) {
+export function identityDPIStatus(x: IdentityType): "DPI" | "WIP" | "NA" {
   const implStatus = normaliseImplementationStatus(x['Status of implementation'])
   if (x['DPI based digital ID\n(to count for Visualisation)'] === 1) {
     return 'DPI'

--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -4,7 +4,7 @@ import { fixURL } from './Util'
 
 type PaymentType = typeof json[number]
 
-export function paymentDPIStatus(x: PaymentType) {
+export function paymentDPIStatus(x: PaymentType): "DPI" | "WIP" | "NA" {
   const implStatus = normaliseImplementationStatus(x['Status of payment system implementation'])
   if (x['Count for DPI'] === 1) { 
     return 'DPI'

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -15,13 +15,29 @@ export function fixURL(dpiType: string, country: string, url: string) {
   }
 }
 
-type DPIData = {
+interface DPIData {
   Country: string,
   'DPI Status': 'DPI' | 'WIP' | 'NA'
 }
 
+/*
+Takes an array of DPI system data.
+Returns an array with 1 item per Country; the most DPI-like where there is more than 1 system per country.
+*/
 export function oneSystemPerCountry (arr: DPIData[]) {
-  const copy = [...arr].reverse() // flip the order so the more dpi like system overwrites
-  const dedupe = [...new Map(copy.map(row => [row.Country, row])).values()]
-  return dedupe.reverse() // be kind rewind
+  const map = arr.reduce((map, row) => {
+    const val = map.get(row.Country)
+    if (val && val["DPI Status"] === 'DPI') {
+      // we already have a DPI-like entry so move on
+      return map
+    }
+    if (val && val["DPI Status"] === row["DPI Status"]) {
+      // the new one isn't more dpi-like so move on
+      return map
+    }
+    // the new row is the first, or more dpi-like, so include it.
+    map.set(row.Country, row)
+    return map
+  }, new Map<string, DPIData>())
+  return [...map.values()]
 }


### PR DESCRIPTION
When filtering the dpi data down to 1 system per coutnry, ensure we pick the most dpi-like system where there is more than 1 to choose from.

Previously we assumed the data would always list the more dpi-like system before the less dpi-like, but this may not be the case.

fixes: https://github.com/olizilla/digital-public-infra-map/issues/29

Note that this bug was not the cause of the difference in the headline stats from the spreadsheet calculation. The website is currently displaying the count of "DPI-like systems **per country**" so where a country has more than 1 DPI-like system for a given category, it only counts as 1 for the headline stat. I believe the spreadsheet calculation is counting "number of DPI-like systems".

License: MIT