### PR TITLE
feat: test out stale-while-revalidate in _headers file

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,12 @@
+/
+	Cache-Control: public, max-age=1, stale-while-revalidate=14400
+
+/digital-payment/
+	Cache-Control: public, max-age=1, stale-while-revalidate=14400
+
+/data-exchange/
+	Cache-Control: public, max-age=1, stale-while-revalidate=14400
+
+/_astro/*
+	! Cache-Control
+	Cache-Control: public, max-age=14400, stale-while-revalidate=14400

--- a/public/_headers
+++ b/public/_headers
@@ -1,12 +1,12 @@
 /
-	Cache-Control: public, max-age=1, stale-while-revalidate=14400
+	Cache-Control: public, max-age=60, stale-while-revalidate=604800
 
 /digital-payment/
-	Cache-Control: public, max-age=1, stale-while-revalidate=14400
+	Cache-Control: public, max-age=60, stale-while-revalidate=604800
 
 /data-exchange/
-	Cache-Control: public, max-age=1, stale-while-revalidate=14400
+	Cache-Control: public, max-age=60, stale-while-revalidate=604800
 
 /_astro/*
 	! Cache-Control
-	Cache-Control: public, max-age=14400, stale-while-revalidate=14400
+	Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
Add a `_headers` file to add `Cache-Control` headers with stale-while-revalidate to html responses.

The intention is to ratchet these up as we don't redeploy the site that often, the map html is quite large, and ideally we can make the site work offline for the duration of the stale-while-revalidate period.

see: https://developers.cloudflare.com/pages/configuration/headers/

License: MIT